### PR TITLE
Fix: perl -MTest::MockTime::HiRes -e 'sleep 1'

### DIFF
--- a/lib/Test/MockTime/HiRes.pm
+++ b/lib/Test/MockTime/HiRes.pm
@@ -18,7 +18,7 @@ our @EXPORT = qw(
     mock_time
 );
 
-our $VERSION = '0.02';
+our $VERSION = '0.03';
 
 my $datetime_was_loaded;
 
@@ -40,7 +40,7 @@ BEGIN {
     *CORE::GLOBAL::time = \&Test::MockTime::time;
 
     *CORE::GLOBAL::sleep = sub ($) {
-        return int(Test::MockTime::HiRes::_sleep($_[0], \&CORE::sleep));
+        return int(Test::MockTime::HiRes::_sleep($_[0], sub {CORE::sleep $_[0]}));
     };
     my $hires_clock_gettime = \&Time::HiRes::clock_gettime;
     my $hires_time = \&Time::HiRes::time;

--- a/t/04_sleep.t
+++ b/t/04_sleep.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Test::MockTime::HiRes;
+
+my @warnings;
+$SIG{__WARN__} = sub {push @warnings, @_};
+
+my $success = eval {
+    sleep 0;
+    1;
+};
+
+is $success, 1, 'sleep does not die';
+is 0+@warnings, 0, 'no warnings';
+
+done_testing;


### PR DESCRIPTION
With version 0.02 the simple command

```
perl -MTest::MockTime::HiRes -e 'sleep 1'
```

fails because it tries to call the undefined subroutine `&CORE::sleep`.

This change fixes it.

All tests on travis are passing. See:

https://travis-ci.org/tfoertsch/perl5-Test-MockTime-HiRes/builds/55475338

Please merge
