### PR TITLE
Fix resolution for usleep() and nanosleep()

### DIFF
--- a/lib/Test/MockTime/HiRes.pm
+++ b/lib/Test/MockTime/HiRes.pm
@@ -60,10 +60,10 @@ BEGIN {
         return Test::MockTime::HiRes::_sleep($_[0], $hires_sleep);
     };
     *Time::HiRes::usleep = sub ($) {
-        return Test::MockTime::HiRes::_sleep($_[0], $hires_usleep, 1000);
+        return Test::MockTime::HiRes::_sleep($_[0], $hires_usleep, 1000_000);
     };
     *Time::HiRes::nanosleep = sub ($) {
-        return Test::MockTime::HiRes::_sleep($_[0], $hires_nanosleep, 1000_000);
+        return Test::MockTime::HiRes::_sleep($_[0], $hires_nanosleep, 1000_000_000);
     };
 
     $datetime_was_loaded = 1 if $INC{'DateTime.pm'};

--- a/t/02_hires.t
+++ b/t/02_hires.t
@@ -18,9 +18,13 @@ sub hires__time_and_sleep : Tests {
         mock_time {
             is Time::HiRes::time(), $now;
             sleep 1;
-            is Time::HiRes::time(), $now + 1;
+            is Time::HiRes::time(), $now + 1, "sleep() works";
             Time::HiRes::sleep 1;
-            is Time::HiRes::time(), $now + 2;
+            is Time::HiRes::time(), $now + 2, "Time::HiRes::sleep() works";
+            Time::HiRes::usleep(1_000_000);
+            cmp_ok Time::HiRes::time() - ($now + 3), '<', 0.000_005, "Time::HiRes::usleep() works";
+            Time::HiRes::nanosleep(1_000_000_000);
+            cmp_ok Time::HiRes::time() - ($now + 4), '<', 0.000_005, "Time::HiRes::nanosleep() works";
         } $now;
 
         cmp_ok Time::HiRes::time() - $now, '<', 2, 'no wait';


### PR DESCRIPTION
Test::MockTime::HiRes::_sleep() was being called with a resolution
divisor of milliseconds instead of microseconds for usleep() and a
resolution divisor of microseconds instead of nanoseconds for
nanosleep(). This caused the elapsed times to be incorrect by a factor
of 1000.

- Add duration tests for usleep() and nanosleep(). These involve floats,
  so are compared to be within 5 microseconds of the expected values.

- Name the duration tests for clarity.

- Fix the resolution divisor used for usleep() and nanosleep().