### PR TITLE
Fix time() inconsistency

### DIFF
--- a/lib/Test/MockTime/HiRes.pm
+++ b/lib/Test/MockTime/HiRes.pm
@@ -70,7 +70,7 @@ BEGIN {
     $datetime_was_loaded = 1 if $INC{'DateTime.pm'};
 }
 
-sub time (&;@) {
+sub time ($;@) {
     my $original = shift;
     defined $Test::MockTime::fixed ? $Test::MockTime::fixed : $original->(@_) + $Test::MockTime::offset;
 }

--- a/lib/Test/MockTime/HiRes.pm
+++ b/lib/Test/MockTime/HiRes.pm
@@ -32,11 +32,6 @@ BEGIN {
         $time = "$time.$usec" if $usec;
         return $time;
     };
-    my $time_original = \&Test::MockTime::time;
-    *Test::MockTime::time = sub () {
-        return int($time_original->());
-    };
-    *CORE::GLOBAL::time = \&Test::MockTime::time;
 
     *CORE::GLOBAL::sleep = sub ($) {
         return int(Test::MockTime::HiRes::_sleep($_[0], sub {CORE::sleep $_[0]}));
@@ -47,6 +42,12 @@ BEGIN {
     my $hires_sleep = \&Time::HiRes::sleep;
     my $hires_usleep = \&Time::HiRes::usleep;
     my $hires_nanosleep = \&Time::HiRes::nanosleep;
+
+    *Test::MockTime::time = sub () {
+        return int(Test::MockTime::HiRes::time($hires_time));
+    };
+    *CORE::GLOBAL::time = \&Test::MockTime::time;
+
     *Time::HiRes::clock_gettime = sub (;$) {
         return Test::MockTime::HiRes::time($hires_clock_gettime, @_);
     };

--- a/t/05_hires.t
+++ b/t/05_hires.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 201;
+use Test::MockTime::HiRes qw/set_relative_time set_absolute_time/;
+
+my @warnings;
+$SIG{__WARN__} = sub {push @warnings, @_};
+my $base_time = time;
+
+for my $step (1 .. 100) {
+    set_relative_time($step/100);
+    is time, int(Time::HiRes::time), "time() equal to Time::HiRes::time() in set_relative_time to 0.$step sec";
+    set_absolute_time($base_time + $step/100);
+    is time, int(Time::HiRes::time), "time() equal to Time::HiRes::time() in set_absolute_time to $base_time + 0.$step sec";
+}
+
+is 0+@warnings, 0, 'no warnings';
+
+done_testing;


### PR DESCRIPTION
This PR fixes two issues:
- make `time()` be always consistent with `Time::HiRes::time()`, even when we need to set time with granularity of less than a second. Corresponding test added.
- fix `time()` prototype. Current one is invalid - just try to move `sub time(&;@)` before `BEGIN` block for module to fail.